### PR TITLE
Removed Note About Enforcement

### DIFF
--- a/guideline-13.md
+++ b/guideline-13.md
@@ -1,5 +1,3 @@
 **13. The plugin page in the directory should include no more than 12 tags.**
 
 Using the names of other plugins as tags should be carefully considered, since it could be construed as “gaming” the search engine.
-
-_NOTE: With the new version of the directory we will be enforcing this behavior._


### PR DESCRIPTION
This is the only rule that mentions enforcement. While those of us involved know that all of these guidelines will be enforced, specifically mentioning enforcement on only one guideline has the potential to create an expectation that it is the only enforced guideline and therefore the only one worth respecting.