### PR TITLE
Removed Statement on Trademark

### DIFF
--- a/guideline-16.md
+++ b/guideline-16.md
@@ -1,3 +1,3 @@
 **16. A complete plugin must be available at the time of submitting the plugin request to the directory.**
 
-All plugins are examined prior to approval, which is why a link to a zip is required. Names cannot be “reserved” for future use, and trademarked names are already protected as much as possible for the legal representatives. Directory names for approved plugins that are not used within a reasonable amount of time may be given to other developers.
+All plugins are examined prior to approval, which is why a link to a zip is required. Names cannot be “reserved” for future use. Directory names for approved plugins that are not used within a reasonable amount of time may be given to other developers.


### PR DESCRIPTION
"Names cannot be 'reserved' for future use." should be enough in this case, and while Trademark is a common reason for name reservation, it is covered in much more depth in the following guideline (17. Respect trademarks).