### PR TITLE
s/anytime/any time/

### DIFF
--- a/guideline-18.md
+++ b/guideline-18.md
@@ -1,5 +1,5 @@
 **18. We reserve the right to alter the Plugin Guidelines at any time with or without notice.**
 
-We reserve the right to update these guidelines at anytime as we feel necessary.
+We reserve the right to update these guidelines at any time as we feel necessary.
 
 We reserve the right to arbitrarily disable or remove any plugin from the directory for any reason whatsoever, even for reasons not explicitly covered by these guidelines.  Our intent is to enforce these guidelines with as much fairness as humanly possible to ensure plugins’ quality and the safety of their users.


### PR DESCRIPTION
>When it is embedded in the adverbial phrase *at any time*, it’s two words because at must be followed by a noun or a noun phrase, and *anytime* doesn’t work as a noun.

http://grammarist.com/spelling/anytime-any-time/