### PR TITLE
Clarifying ads and upsells

### DIFF
--- a/guideline-11.md
+++ b/guideline-11.md
@@ -4,6 +4,6 @@ Users prefer and expect plugins to feel like part of WordPress. Constant nags an
 
 Upgrade prompts, notices, and alerts should be limited in scope and used sparingly or only on the plugin’s setting page. Any site wide notices or embedded dashboard widgets _must_ be dismissible. Error messages should include information on how to resolve the issue.
 
-Advertising within the WordPress Dashboard should be avoided. While developers are permitted to promote their own products and services, historically they have been ineffective; ideally users rarely visit these screens. Remember: tracking referrals via those ads is not permitted (see guideline 7) and most third-party systems do not permit back-end ads (notably, Google Ads). Abusing the guidelines of an advertising system will result in such actions being reported.
+Advertising within the WordPress Dashboard should be avoided. While developers are permitted to promote their own products and services, historically they have been ineffective; ideally users rarely visit these screens. Remember: tracking referrals via those ads is not permitted (see guideline 7) and most third-party systems do not permit back-end advertisements (notably, Google). Abusing the guidelines of an advertising system will result in such actions being reported.
 
 Developers are welcome and encouraged to include links to their own sites or social networks, as well as locally (within the plugin) including images to enhance that experience.

--- a/guideline-11.md
+++ b/guideline-11.md
@@ -2,8 +2,8 @@
 
 Users prefer and expect plugins to feel like part of WordPress. Constant nags and overwhelming the admin dashboard with unnecessary alerts detract from this experience.
 
-Upgrade prompts and alerts should be limited in scope and used sparingly or only on the plugin’s setting page. Embedded dashboard widgets must be dismissable. Error messages should include information on how to resolve the issue. 
+Upgrade prompts, notices, and alerts should be limited in scope and used sparingly or only on the plugin’s setting page. Similarly, embedded dashboard widgets must be dismissible and error messages should include information on how to resolve the issue.
 
-Banner or text link advertising should be excluded from a plugin, including on its settings screen. Advertising on the WordPress Dashboard is historically ineffective, as ideally users rarely visit these screens. Similarly, third party ad systems rarely permit their usage on admin-only screens (notably, Google Ads does not permit its usage there); if they do permit back-end ads, the quality will be low as those systems cannot see the page content to determine good ads. Abusing the guidelines of an advertising system will result in such actions reported to the advertising system.
+Advertising within the WordPress Dashboard should be avoided. While developers are permitted to promote their own products and services, historically they have been ineffective; ideally users rarely visit these screens. Remember: tracking referrals via those ads is not permitted (see guideline 7) and most third-party systems do not permit back-end ads (notably, Google Ads). Abusing the guidelines of an advertising system will result in such actions being reported.
 
 Developers are welcome and encouraged to include links to their own sites or social networks, as well as locally (within the plugin) including images to enhance that experience.

--- a/guideline-11.md
+++ b/guideline-11.md
@@ -2,7 +2,7 @@
 
 Users prefer and expect plugins to feel like part of WordPress. Constant nags and overwhelming the admin dashboard with unnecessary alerts detract from this experience.
 
-Upgrade prompts, notices, and alerts should be limited in scope and used sparingly or only on the plugin’s setting page. Similarly, embedded dashboard widgets must be dismissible and error messages should include information on how to resolve the issue.
+Upgrade prompts, notices, and alerts should be limited in scope and used sparingly or only on the plugin’s setting page. Any site wide notices or embedded dashboard widgets _must_ be dismissible. Error messages should include information on how to resolve the issue.
 
 Advertising within the WordPress Dashboard should be avoided. While developers are permitted to promote their own products and services, historically they have been ineffective; ideally users rarely visit these screens. Remember: tracking referrals via those ads is not permitted (see guideline 7) and most third-party systems do not permit back-end ads (notably, Google Ads). Abusing the guidelines of an advertising system will result in such actions being reported.
 


### PR DESCRIPTION
* Abide by all other guidelines
* Clarify sitewides must be dismissible
* Remove mention of 3rd party adds (covered in tracking - see G7)
* Using 3rd party systems for your alerts/ads may not be permitted by THEM

Props: @JDGrimes, @dancameron, @tnorthcutt

Fixes #9