### PR TITLE
Remove specific file type for license file

### DIFF
--- a/guideline-02.md
+++ b/guideline-02.md
@@ -1,3 +1,3 @@
-**2. Include a license in your plugin with a license.txt file.**
+**2. Include a license in your plugin with a license file.**
 
-Without a license.txt file, or referencing and/or declaring a license within code comments or a `readme.txt` file, the plugin and all its components are considered GPLv2 or later.
+Without a license file, or referencing and/or declaring a license within code comments or a `readme.txt` file, the plugin and all its components are considered GPLv2 or later.


### PR DESCRIPTION
Presumably, `license.txt`, `license.md` and `LICENSE` are examples of accepted file types, so this change focuses the point on there being some sort of license (within any type of file, or otherwise referenced in code / comments), rather that it specifically being a `.txt` file type.

If this is indeed the case, then it may reduce support queries asking why `.txt` and not `.md` etc.