### PR TITLE
Software as a Service instead of Serviceware

### DIFF
--- a/guideline-06.md
+++ b/guideline-06.md
@@ -1,9 +1,9 @@
-**6. Serviceware _is_ permitted in the directory.**
+**6. Software as a Service _is_ permitted in the directory.**
 
 Plugins that act as an interface to some external third party service (e.g. a video hosting site) are allowed, even for paid services. The service itself must provide functionality of substance and be clearly documented in the readme file submitted with the plugin, preferably with a link to the service’s Terms of Use.
 
 Services and functionality _not_ allowed include:
 
 * A service that exists for the sole purpose of validating licenses or keys while all functional aspects of the plugin are included locally is not permitted.
-* Creation of a service by moving arbitrary code out of the plugin so that the service may falsely appear to provide supplemented functionality is also prohibited.
-* Storefronts are not services, and a plugin that acts only as a front-end for products to be purchased from external systems will not be accepted into the directory.
+* Creation of a service by moving arbitrary code out of the plugin so that the service may falsely appear to provide supplemented functionality is prohibited.
+* Storefronts are not services. A plugin that acts only as a front-end for products to be purchased from external systems will not be accepted.


### PR DESCRIPTION
Changing “Serviceware” to “Software as a Service” as the term is not well know.

props @dmcann

Fixes #26