### PR TITLE
Update to Guideline 13 + List of external libraries.

### DIFF
--- a/.github/workflows/generate-external-libraries.yml
+++ b/.github/workflows/generate-external-libraries.yml
@@ -1,0 +1,21 @@
+name: Update list of External Libraries
+
+on:
+  workflow_dispatch:
+
+jobs:
+  modify-and-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Execute run the Script to modify the list of external libraries
+      run: ./dev/generate-external-libraries.sh --format=html --file=external-libraries.md
+
+    - name: Commit and push if there are changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Update list of external libraries to latest version of WordPress.
+        branch: trunk

--- a/.github/workflows/generate-external-libraries.yml
+++ b/.github/workflows/generate-external-libraries.yml
@@ -7,6 +7,11 @@ jobs:
   modify-and-commit:
     runs-on: ubuntu-latest
 
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -18,10 +23,10 @@ jobs:
         version: 1.0 # used to clear cache if needed.
 
     - name: Execute run the Script to modify the list of external libraries
-      run: ./dev/generate-external-libraries.sh --format=html --file=external-libraries.md
+      run: ./dev/generate-external-libraries.sh --format html --input external-libraries.md
 
     - name: Commit and push if there are changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Update list of external libraries to latest version of WordPress.
-        branch: trunk
+        branch: ${{ github.head_ref }}

--- a/.github/workflows/generate-external-libraries.yml
+++ b/.github/workflows/generate-external-libraries.yml
@@ -11,6 +11,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Cache and install jq and perl
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: jq perl
+        version: 1.0 # used to clear cache if needed.
+
     - name: Execute run the Script to modify the list of external libraries
       run: ./dev/generate-external-libraries.sh --format=html --file=external-libraries.md
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ If you feel a guideline’s explanation is unclear, please create an issue or a 
 17. [Plugins must respect trademarks, copyrights, and project names.](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/guideline-17.md)
 18. [We reserve the right to maintain the Plugin Directory to the best of our ability.](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/guideline-18.md)
 
+**Extras:**
+- [Block Specific guidelines](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/blocks.md)
+- [List of External Libraries](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/external-libraries.md)
+
 ## License
 
 The content has two licenses:

--- a/dev/generate-external-libraries.sh
+++ b/dev/generate-external-libraries.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed. Please install it and try again."
+    exit 1
+fi
+
+# Check if perl is installed
+if ! command -v perl > /dev/null; then
+    echo "Error: perl is not installed. Please install perl to continue."
+    exit 1
+fi
+
+BASE_URL="https://api.wordpress.org/core/credits/1.1/"
+FORMAT="markdown"
+VERSION=""
+FILE=""
+
+display_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo
+    echo "Fetch data from the WordPress API and format the output."
+    echo
+    echo "Options:"
+    echo "  -f, --format FORMAT  Set the output format. Available formats: markdown, comma, html. Default: markdown."
+    echo "  -v, --version VER    Set the WordPress version. It will fetch data for the specified version."
+    echo "  -i, --input FILE     Specify a file to replace the existing UL with the same ID as the generated one."
+    echo "  -h, --help           Display this help message."
+    echo
+    exit 0
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -f|--format)
+            FORMAT="$2";
+            shift
+            ;;
+        -v|--version)
+            VERSION="?version=$2";
+            shift
+            ;;
+        -i|--input)
+            FILE="$2";
+            shift
+            ;;
+        -h|--help)
+            display_help
+            ;;
+        *)
+            echo "Unknown parameter: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Check for format and file compatibility
+if [[ ! -z "$FILE" && "$FORMAT" != "html" ]]; then
+    echo "Error: When specifying a file with the -i/--input option, the format must be set to 'html'."
+    exit 1
+fi
+
+# Build the full URL
+FULL_URL="${BASE_URL}${VERSION}"
+
+# Fetch the JSON from the URL
+JSON_DATA=$(curl -s "$FULL_URL")
+
+# Extract and format data based on the specified format
+case "$FORMAT" in
+    "markdown")
+        DATA=$(echo "$JSON_DATA" | jq -r '.groups.libraries.data[] | "- [" + .[0] + "](" + .[1] + ")"')
+        echo "$DATA"
+        ;;
+    "comma")
+        DATA=$(echo "$JSON_DATA" | jq -r '[.groups.libraries.data[] | "[" + .[0] + "](" + .[1] + ")"] | join(", ")')
+        echo "$DATA"
+        ;;
+    "html")
+        DATA=$(echo "$JSON_DATA" | jq -r '.groups.libraries.data[] | "\t<li><a href=\"" + .[1] + "\" rel=\"noopener noreferrer nofollow\" target=\"_blank\">" + .[0] + "</a></li>"')
+        NEW_LIST="<ul id=\"list-external-libraries\">\n$DATA\n</ul>"
+
+        # If a file is specified, replace the existing UL with the new one
+        if [[ ! -z "$FILE" ]]; then
+            # Use perl to replace the ul with a given id
+            perl -i -p0e "s|<ul id=\"list-external-libraries\">.*?</ul>|$NEW_LIST|gs" "$FILE"
+        else
+            echo "$NEW_LIST"
+        fi
+        ;;
+    *)
+        echo "Error: Invalid format. Available formats: markdown, comma, html"
+        exit 1
+        ;;
+esac

--- a/external-libraries.md
+++ b/external-libraries.md
@@ -1,0 +1,48 @@
+<h2>List of external libraries included on WordPress</h2>
+
+This list was generated based on data from the [WordPress.org official API](https://codex.wordpress.org/WordPress.org_API#Credits) with data from version **6.3 of WordPress**. But it's not a complete list, because some libraries are not included in the API.
+
+<ul>
+	<li><a href="https://babeljs.io/docs/en/babel-polyfill" rel="noopener noreferrer nofollow" target="_blank">Babel Polyfill</a></li>
+	<li><a href="http://backbonejs.org/" rel="noopener noreferrer nofollow" target="_blank">Backbone.js</a></li>
+	<li><a href="https://squirrelmail.org/" rel="noopener noreferrer nofollow" target="_blank">Class POP3</a></li>
+	<li><a href="https://clipboardjs.com/" rel="noopener noreferrer nofollow" target="_blank">clipboard.js</a></li>
+	<li><a href="https://github.com/jonathantneal/closest" rel="noopener noreferrer nofollow" target="_blank">Closest</a></li>
+	<li><a href="https://codemirror.net/" rel="noopener noreferrer nofollow" target="_blank">CodeMirror</a></li>
+	<li><a href="https://plugins.jquery.com/color/" rel="noopener noreferrer nofollow" target="_blank">Color Animations</a></li>
+	<li><a href="http://getid3.sourceforge.net/" rel="noopener noreferrer nofollow" target="_blank">getID3()</a></li>
+	<li><a href="https://github.com/jimmywarting/FormData" rel="noopener noreferrer nofollow" target="_blank">FormData</a></li>
+	<li><a href="https://pear.horde.org/" rel="noopener noreferrer nofollow" target="_blank">Horde Text Diff</a></li>
+	<li><a href="http://cherne.net/brian/resources/jquery.hoverIntent.html" rel="noopener noreferrer nofollow" target="_blank">hoverIntent</a></li>
+	<li><a href="http://odyniec.net/projects/imgareaselect/" rel="noopener noreferrer nofollow" target="_blank">imgAreaSelect</a></li>
+	<li><a href="https://github.com/Automattic/Iris" rel="noopener noreferrer nofollow" target="_blank">Iris</a></li>
+	<li><a href="https://jquery.com/" rel="noopener noreferrer nofollow" target="_blank">jQuery</a></li>
+	<li><a href="https://jqueryui.com/" rel="noopener noreferrer nofollow" target="_blank">jQuery UI</a></li>
+	<li><a href="https://github.com/tzuryby/jquery.hotkeys" rel="noopener noreferrer nofollow" target="_blank">jQuery Hotkeys</a></li>
+	<li><a href="http://benalman.com/projects/jquery-misc-plugins/" rel="noopener noreferrer nofollow" target="_blank">jQuery serializeObject</a></li>
+	<li><a href="https://plugins.jquery.com/query-object/" rel="noopener noreferrer nofollow" target="_blank">jQuery.query</a></li>
+	<li><a href="https://github.com/pvulgaris/jquery.suggest" rel="noopener noreferrer nofollow" target="_blank">jQuery.suggest</a></li>
+	<li><a href="http://touchpunch.furf.com/" rel="noopener noreferrer nofollow" target="_blank">jQuery UI Touch Punch</a></li>
+	<li><a href="https://github.com/douglascrockford/JSON-js" rel="noopener noreferrer nofollow" target="_blank">json2</a></li>
+	<li><a href="https://lodash.com/" rel="noopener noreferrer nofollow" target="_blank">Lodash</a></li>
+	<li><a href="http://masonry.desandro.com/" rel="noopener noreferrer nofollow" target="_blank">Masonry</a></li>
+	<li><a href="http://mediaelementjs.com/" rel="noopener noreferrer nofollow" target="_blank">MediaElement.js</a></li>
+	<li><a href="http://momentjs.com/" rel="noopener noreferrer nofollow" target="_blank">Moment</a></li>
+	<li><a href="http://www.phpconcept.net/pclzip/" rel="noopener noreferrer nofollow" target="_blank">PclZip</a></li>
+	<li><a href="https://www.phpclasses.org/package/1743-PHP-FTP-client-in-pure-PHP.html" rel="noopener noreferrer nofollow" target="_blank">PemFTP</a></li>
+	<li><a href="http://www.openwall.com/phpass/" rel="noopener noreferrer nofollow" target="_blank">phpass</a></li>
+	<li><a href="https://github.com/PHPMailer/PHPMailer" rel="noopener noreferrer nofollow" target="_blank">PHPMailer</a></li>
+	<li><a href="http://www.plupload.com/" rel="noopener noreferrer nofollow" target="_blank">Plupload</a></li>
+	<li><a href="https://github.com/paragonie/random_compat" rel="noopener noreferrer nofollow" target="_blank">random_compat</a></li>
+	<li><a href="https://reactjs.org/" rel="noopener noreferrer nofollow" target="_blank">React</a></li>
+	<li><a href="https://redux.js.org/" rel="noopener noreferrer nofollow" target="_blank">Redux</a></li>
+	<li><a href="http://requests.ryanmccue.info/" rel="noopener noreferrer nofollow" target="_blank">Requests</a></li>
+	<li><a href="http://simplepie.org/" rel="noopener noreferrer nofollow" target="_blank">SimplePie</a></li>
+	<li><a href="https://code.google.com/archive/p/php-ixr/" rel="noopener noreferrer nofollow" target="_blank">The Incutio XML-RPC Library</a></li>
+	<li><a href="http://codylindley.com/thickbox/" rel="noopener noreferrer nofollow" target="_blank">Thickbox</a></li>
+	<li><a href="https://www.tinymce.com/" rel="noopener noreferrer nofollow" target="_blank">TinyMCE</a></li>
+	<li><a href="https://github.com/twitter/twemoji" rel="noopener noreferrer nofollow" target="_blank">Twemoji</a></li>
+	<li><a href="http://underscorejs.org/" rel="noopener noreferrer nofollow" target="_blank">Underscore.js</a></li>
+	<li><a href="https://github.com/github/fetch" rel="noopener noreferrer nofollow" target="_blank">whatwg-fetch</a></li>
+	<li><a href="https://github.com/dropbox/zxcvbn" rel="noopener noreferrer nofollow" target="_blank">zxcvbn</a></li>
+</ul>

--- a/external-libraries.md
+++ b/external-libraries.md
@@ -2,7 +2,7 @@
 
 This list was generated based on data from the [WordPress.org official API](https://codex.wordpress.org/WordPress.org_API#Credits) with data from version **6.3 of WordPress**. But it's not a complete list, because some libraries are not included in the API.
 
-<ul>
+<ul id="list-external-libraries">
 	<li><a href="https://babeljs.io/docs/en/babel-polyfill" rel="noopener noreferrer nofollow" target="_blank">Babel Polyfill</a></li>
 	<li><a href="http://backbonejs.org/" rel="noopener noreferrer nofollow" target="_blank">Backbone.js</a></li>
 	<li><a href="https://squirrelmail.org/" rel="noopener noreferrer nofollow" target="_blank">Class POP3</a></li>

--- a/guideline-13.md
+++ b/guideline-13.md
@@ -2,6 +2,6 @@
 
 WordPress includes a number of useful libraries, such as jQuery, Atom Lib, SimplePie, PHPMailer, PHPass, and more. For security and stability reasons plugins may not include those libraries in their own code. Instead plugins must use the versions of those libraries packaged with WordPress. 
 
-While we do not yet have an updated public facing page to list all these libraries, please review the <a href="https://developer.wordpress.org/plugins/wordpress-org/external-libraries/">list of the external libraries included in WordPress from what is listed in the WordPress credits API</a>.
+While we do not yet have a public facing page to list all these libraries, please review the <a href="https://developer.wordpress.org/plugins/wordpress-org/external-libraries/">list of the external libraries included in WordPress based on the WordPress credits API</a>.
 
 For a list of all javascript libraries included in WordPress, please review <a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-and-js-libraries-included-and-registered-by-wordpress">Default Scripts Included and Registered by WordPress</a>.

--- a/guideline-13.md
+++ b/guideline-13.md
@@ -1,5 +1,7 @@
 <h4>13. Plugins must use WordPress' default libraries.</h4>
 
-WordPress includes a number of useful libraries, such as jQuery, Atom Lib, SimplePie, PHPMailer, PHPass, and more. For security and stability reasons plugins may not include those libraries in their own code. Instead plugins must use the versions of those libraries packaged with WordPress.
+WordPress includes a number of useful libraries, such as jQuery, Atom Lib, SimplePie, PHPMailer, PHPass, and more. For security and stability reasons plugins may not include those libraries in their own code. Instead plugins must use the versions of those libraries packaged with WordPress. 
 
-For a list of all javascript libraries included in WordPress, please review <a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/#notes">Default Scripts Included and Registered by WordPress</a>.
+While we do not yet have an updated public facing page to list all these libraries, please review the <a href="https://developer.wordpress.org/plugins/wordpress-org/external-libraries/">list of the external libraries included in WordPress from what is listed in the WordPress credits API</a>.
+
+For a list of all javascript libraries included in WordPress, please review <a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-and-js-libraries-included-and-registered-by-wordpress">Default Scripts Included and Registered by WordPress</a>.


### PR DESCRIPTION
After some internal conversations from the Plugin Review team we believe it's important to improve guideline 13 about external libraries to match our expectations from plugins submitted to the repository.

I've took the liberty to include a compiled list of all libraries included on the `https://api.wordpress.org/core/credits/1.1/`, I've created a small script that renders that list for me in HTML and Markdown, so updating that list should be super easy. 

We could even include as a small GitHub action so that updating the list is less manual, but I don't know about the policy for running GitHub Actions on this Org.

Would love feedback on the changes and on the suggestion I made above.

---

### Update for GitHub Workflow

I've created personal repository to test this workflow, see the link below to see it working before you Code Review on this.
https://github.com/bordoni/workflow-dev/actions/runs/5905221399/job/16018906527

Here is a video of how it would be to run the workflow manually to get the latest libraries from the API.

![screenshot-2023-08-18-13-11-56](https://github.com/WordPress/wporg-plugin-guidelines/assets/236579/8c6135f0-01af-498b-a716-2fa6fdb14a01)





