### PR TITLE
Improve Guideline 13 with a List of External Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ If you feel a guideline’s explanation is unclear, please create an issue or a 
 17. [Plugins must respect trademarks, copyrights, and project names.](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/guideline-17.md)
 18. [We reserve the right to maintain the Plugin Directory to the best of our ability.](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/guideline-18.md)
 
+**Extras:**
+- [Block Specific guidelines](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/blocks.md)
+- [List of External Libraries](https://github.com/wordpress/wporg-plugin-guidelines/blob/master/external-libraries.md)
+
 ## License
 
 The content has two licenses:

--- a/external-libraries.md
+++ b/external-libraries.md
@@ -1,0 +1,48 @@
+<h2>List of external libraries included on WordPress</h2>
+
+This list was generated based on data from the [WordPress.org official API](https://codex.wordpress.org/WordPress.org_API#Credits) with data from version **6.3 of WordPress**. But it's not a complete list, because some libraries are not included in the API.
+
+<ul id="list-external-libraries">
+	<li><a href="https://babeljs.io/docs/en/babel-polyfill" rel="noopener noreferrer nofollow" target="_blank">Babel Polyfill</a></li>
+	<li><a href="https://backbonejs.org/" rel="noopener noreferrer nofollow" target="_blank">Backbone.js</a></li>
+	<li><a href="https://squirrelmail.org/" rel="noopener noreferrer nofollow" target="_blank">Class POP3</a></li>
+	<li><a href="https://clipboardjs.com/" rel="noopener noreferrer nofollow" target="_blank">clipboard.js</a></li>
+	<li><a href="https://github.com/jonathantneal/closest" rel="noopener noreferrer nofollow" target="_blank">Closest</a></li>
+	<li><a href="https://codemirror.net/" rel="noopener noreferrer nofollow" target="_blank">CodeMirror</a></li>
+	<li><a href="https://plugins.jquery.com/color/" rel="noopener noreferrer nofollow" target="_blank">Color Animations</a></li>
+	<li><a href="https://www.getid3.org/" rel="noopener noreferrer nofollow" target="_blank">getID3()</a></li>
+	<li><a href="https://github.com/jimmywarting/FormData" rel="noopener noreferrer nofollow" target="_blank">FormData</a></li>
+	<li><a href="https://pear.horde.org/" rel="noopener noreferrer nofollow" target="_blank">Horde Text Diff</a></li>
+	<li><a href="https://github.com/briancherne/jquery-hoverIntent" rel="noopener noreferrer nofollow" target="_blank">hoverIntent</a></li>
+	<li><a href="https://github.com/odyniec/imgareaselect" rel="noopener noreferrer nofollow" target="_blank">imgAreaSelect</a></li>
+	<li><a href="https://github.com/Automattic/Iris" rel="noopener noreferrer nofollow" target="_blank">Iris</a></li>
+	<li><a href="https://jquery.com/" rel="noopener noreferrer nofollow" target="_blank">jQuery</a></li>
+	<li><a href="https://jqueryui.com/" rel="noopener noreferrer nofollow" target="_blank">jQuery UI</a></li>
+	<li><a href="https://github.com/tzuryby/jquery.hotkeys" rel="noopener noreferrer nofollow" target="_blank">jQuery Hotkeys</a></li>
+	<li><a href="https://benalman.com/projects/jquery-misc-plugins/" rel="noopener noreferrer nofollow" target="_blank">jQuery serializeObject</a></li>
+	<li><a href="https://plugins.jquery.com/query-object/" rel="noopener noreferrer nofollow" target="_blank">jQuery.query</a></li>
+	<li><a href="https://github.com/pvulgaris/jquery.suggest" rel="noopener noreferrer nofollow" target="_blank">jQuery.suggest</a></li>
+	<li><a href="https://github.com/furf/jquery-ui-touch-punch" rel="noopener noreferrer nofollow" target="_blank">jQuery UI Touch Punch</a></li>
+	<li><a href="https://github.com/douglascrockford/JSON-js" rel="noopener noreferrer nofollow" target="_blank">json2</a></li>
+	<li><a href="https://lodash.com/" rel="noopener noreferrer nofollow" target="_blank">Lodash</a></li>
+	<li><a href="https://masonry.desandro.com/" rel="noopener noreferrer nofollow" target="_blank">Masonry</a></li>
+	<li><a href="https://www.mediaelementjs.com/" rel="noopener noreferrer nofollow" target="_blank">MediaElement.js</a></li>
+	<li><a href="https://momentjs.com/" rel="noopener noreferrer nofollow" target="_blank">Moment</a></li>
+	<li><a href="https://www.phpconcept.net/" rel="noopener noreferrer nofollow" target="_blank">PclZip</a></li>
+	<li><a href="https://www.phpclasses.org/package/1743-PHP-FTP-client-in-pure-PHP.html" rel="noopener noreferrer nofollow" target="_blank">PemFTP</a></li>
+	<li><a href="https://www.openwall.com/phpass/" rel="noopener noreferrer nofollow" target="_blank">phpass</a></li>
+	<li><a href="https://github.com/PHPMailer/PHPMailer" rel="noopener noreferrer nofollow" target="_blank">PHPMailer</a></li>
+	<li><a href="https://www.plupload.com/" rel="noopener noreferrer nofollow" target="_blank">Plupload</a></li>
+	<li><a href="https://github.com/paragonie/random_compat" rel="noopener noreferrer nofollow" target="_blank">random_compat</a></li>
+	<li><a href="https://reactjs.org/" rel="noopener noreferrer nofollow" target="_blank">React</a></li>
+	<li><a href="https://redux.js.org/" rel="noopener noreferrer nofollow" target="_blank">Redux</a></li>
+	<li><a href="https://requests.ryanmccue.info/" rel="noopener noreferrer nofollow" target="_blank">Requests</a></li>
+	<li><a href="https://simplepie.org/" rel="noopener noreferrer nofollow" target="_blank">SimplePie</a></li>
+	<li><a href="https://code.google.com/archive/p/php-ixr/" rel="noopener noreferrer nofollow" target="_blank">The Incutio XML-RPC Library</a></li>
+	<li><a href="https://codylindley.com/thickbox/" rel="noopener noreferrer nofollow" target="_blank">Thickbox</a></li>
+	<li><a href="https://www.tinymce.com/" rel="noopener noreferrer nofollow" target="_blank">TinyMCE</a></li>
+	<li><a href="https://github.com/twitter/twemoji" rel="noopener noreferrer nofollow" target="_blank">Twemoji</a></li>
+	<li><a href="https://underscorejs.org/" rel="noopener noreferrer nofollow" target="_blank">Underscore.js</a></li>
+	<li><a href="https://github.com/github/fetch" rel="noopener noreferrer nofollow" target="_blank">whatwg-fetch</a></li>
+	<li><a href="https://github.com/dropbox/zxcvbn" rel="noopener noreferrer nofollow" target="_blank">zxcvbn</a></li>
+</ul>

--- a/guideline-13.md
+++ b/guideline-13.md
@@ -1,5 +1,7 @@
 <h4>13. Plugins must use WordPress' default libraries.</h4>
 
-WordPress includes a number of useful libraries, such as jQuery, Atom Lib, SimplePie, PHPMailer, PHPass, and more. For security and stability reasons plugins may not include those libraries in their own code. Instead plugins must use the versions of those libraries packaged with WordPress.
+WordPress includes a number of useful libraries, such as jQuery, Atom Lib, SimplePie, PHPMailer, PHPass, and more. For security and stability reasons plugins may not include those libraries in their own code. Instead plugins must use the versions of those libraries packaged with WordPress. 
 
-For a list of all javascript libraries included in WordPress, please review <a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/#notes">Default Scripts Included and Registered by WordPress</a>.
+While we do not yet have a public facing page to list all these libraries, please review the <a href="https://developer.wordpress.org/plugins/wordpress-org/external-libraries/">list of the external libraries included in WordPress based on the WordPress credits API</a>.
+
+For a list of all javascript libraries included in WordPress, please review <a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-and-js-libraries-included-and-registered-by-wordpress">Default Scripts Included and Registered by WordPress</a>.


### PR DESCRIPTION
After some internal conversations from the Plugin Review team we believe it's important to improve guideline 13 about external libraries to match our expectations from plugins submitted to the repository.

I've took the liberty to include a compiled list of all libraries included on the https://api.wordpress.org/core/credits/1.1/

---

This PR is a simplified version of #83, @pkevan asked me to split that one into two PRs so we can get them merged separately.

