### PR TITLE
Create a Workflow to update the External Libraries Document

### DIFF
--- a/.github/workflows/external-libraries.yml
+++ b/.github/workflows/external-libraries.yml
@@ -1,0 +1,36 @@
+name: Update list of External Libraries
+
+on:
+  workflow_dispatch:
+    inputs:
+      wp_version:
+        description: 'WordPress Version'
+        required: true
+        type: text
+
+jobs:
+  modify-and-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Cache and install jq and perl
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: jq perl
+        version: 1.0 # used to clear cache if needed.
+
+    - name: Execute run the Script to modify the list of external libraries
+      run: ./dev/external-libraries.sh --format html --input external-libraries.md --version ${{ github.event.inputs.wp_version }}
+
+    - name: Commit and push if there are changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Update list of external libraries to latest version of WordPress.
+        branch: ${{ github.head_ref }}

--- a/dev/external-libraries.sh
+++ b/dev/external-libraries.sh
@@ -7,9 +7,9 @@ YELLOW="\033[1;33m"
 RESET="\033[0m"
 
 # Header
-echo -e "${YELLOW}======================================="
-echo -e " WordPress API External Libraries Fetcher Script"
-echo -e "=======================================${RESET}"
+echo -e "${YELLOW}=================================================${RESET}"
+echo -e "${YELLOW} WordPress API External Libraries Fetcher Script ${RESET}"
+echo -e "${YELLOW}=================================================${RESET}"
 echo
 
 # Check if jq is installed

--- a/dev/external-libraries.sh
+++ b/dev/external-libraries.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Define colors
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RESET="\033[0m"
+
+# Header
+echo -e "${YELLOW}======================================="
+echo -e " WordPress API External Libraries Fetcher Script"
+echo -e "=======================================${RESET}"
+echo
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}Error: jq is not installed. Please install it and try again.${RESET}"
+    exit 1
+fi
+
+# Check if perl is installed
+if ! command -v perl > /dev/null; then
+    echo -e "${RED}Error: perl is not installed. Please install perl to continue.${RESET}"
+    exit 1
+fi
+
+BASE_URL="https://api.wordpress.org/core/credits/1.1/"
+FORMAT="markdown"
+VERSION=""
+VERSION_URL=""
+FILE=""
+
+display_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo
+    echo "Fetch data from the WordPress API and format the output."
+    echo
+    echo "Options:"
+    echo "  -f, --format FORMAT  Set the output format. Available formats: markdown, comma, html. Default: markdown."
+    echo "  -v, --version VER    Set the WordPress version. It will fetch data for the specified version."
+    echo "  -i, --input FILE     Specify a file to replace the existing UL with the same ID as the generated one."
+    echo "  -h, --help           Display this help message."
+    echo
+    exit 0
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -f|--format)
+            FORMAT="$2";
+            echo -e "${GREEN}Setting output format to: $FORMAT${RESET}"
+            shift
+            ;;
+        -v|--version)
+            VERSION="$2";
+            VERSION_URL="?version=$VERSION"
+            echo -e "${GREEN}Setting WordPress version to: $VERSION${RESET}"
+            shift
+            ;;
+        -i|--input)
+            FILE="$2";
+            echo -e "${GREEN}Setting input file to: $FILE${RESET}"
+            shift
+            ;;
+        -h|--help)
+            display_help
+            ;;
+        *)
+            echo -e "${RED}Unknown parameter: $1${RESET}"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Check for format and file compatibility
+if [[ ! -z "$FILE" && "$FORMAT" != "html" ]]; then
+    echo -e "${RED}Error: When specifying a file with the -i/--input option, the format must be set to 'html'.${RESET}"
+    exit 1
+fi
+
+# Build the full URL
+FULL_URL="${BASE_URL}${VERSION_URL}"
+echo -e "${GREEN}Built full URL: $FULL_URL${RESET}"
+
+# Fetch the JSON from the URL
+JSON_DATA=$(curl -s "$FULL_URL")
+CURL_EXIT_STATUS=$?
+
+if [[ $CURL_EXIT_STATUS -ne 0 ]]; then
+    echo -e "${RED}Error: Failed to fetch data from the URL. CURL Exit Status: $CURL_EXIT_STATUS${RESET}"
+    exit 1
+else
+    echo -e "${GREEN}Successfully fetched data from the URL.${RESET}"
+fi
+
+# Check if JSON data is empty
+if [[ -z "$JSON_DATA" ]]; then
+    echo -e "${RED}Error: Received empty data from the URL.${RESET}"
+    exit 1
+fi
+
+# Extract and format data based on the specified format
+echo -e "${GREEN}Extracting and formatting data...${RESET}"
+case "$FORMAT" in
+    "markdown")
+        DATA=$(echo "$JSON_DATA" | jq -r '.groups.libraries.data[] | "- [" + .[0] + "](" + .[1] + ")"')
+        echo "$DATA"
+        ;;
+    "comma")
+        DATA=$(echo "$JSON_DATA" | jq -r '[.groups.libraries.data[] | "[" + .[0] + "](" + .[1] + ")"] | join(", ")')
+        echo "$DATA"
+        ;;
+    "html")
+        DATA=$(echo "$JSON_DATA" | jq -r '.groups.libraries.data[] | "\t<li><a href=\"" + .[1] + "\" rel=\"noopener noreferrer nofollow\" target=\"_blank\">" + .[0] + "</a></li>"')
+        NEW_LIST="<ul id=\"list-external-libraries\">\n$DATA\n</ul>"
+
+        # If a file is specified, replace the existing UL with the new one
+        if [[ ! -z "$FILE" ]]; then
+            # Use perl to replace the ul with a given id
+            perl -i -p0e "s|<ul id=\"list-external-libraries\">.*?</ul>|$NEW_LIST|gs" "$FILE"
+
+            if [[ ! -z "$VERSION" ]]; then
+              perl -i -p0e "s|\*\*.*? of WordPress\*\*|\*\*$VERSION of WordPress\*\*|gs" "$FILE"
+            fi
+        else
+            echo "$NEW_LIST"
+        fi
+        ;;
+    *)
+        echo -e "${RED}Error: Invalid format. Available formats: markdown, comma, html.${RESET}"
+        exit 1
+        ;;
+esac
+
+# End message
+echo -e "${YELLOW}Script execution completed.${RESET}"


### PR DESCRIPTION
After some internal conversations from the Plugin Review team we believe it's important to improve guideline 13 about external libraries to match our expectations from plugins submitted to the repository.

I've took the liberty to include a compiled list of all libraries included on the https://api.wordpress.org/core/credits/1.1/

This is just the PR to handle the Workflow of updating the the External Libraries document, see #84

| Workflow Running | Inputs available |
| - | - |
| ![screenshot-2023-09-16-01-08-13@2x](https://github.com/WordPress/wporg-plugin-guidelines/assets/236579/ebc0bbaa-a0d9-4105-b2fe-977503bc1cac) | ![screenshot-2023-09-16-01-07-06@2x](https://github.com/WordPress/wporg-plugin-guidelines/assets/236579/a4bf8f8e-57c8-41d7-a87e-a63e4715ec06) |

---

This PR is a simplified version of #83, @pkevan asked me to split that one into two PRs so we can get them merged separately.