### PR TITLE
Proposed change to guideline 4 to clarify use of build tools

### DIFF
--- a/guideline-04.md
+++ b/guideline-04.md
@@ -1,12 +1,13 @@
-<h4>4. Code must be (mostly) human readable.</h4>
+<h4>4. Original source code and  build tools must be publicly available.</h4>
 
-Obscuring code by hiding it with techniques or systems similar to <code>p,a,c,k,e,r</code>'s obfuscate feature, uglify's mangle, or unclear naming conventions such as <code>$z12sdf813d</code>, is not permitted in the directory. Making code non-human readable forces future developers to face an unnecessary hurdle, as well as being a common vector for hidden, malicious code.
-
-We require developers to provide public, maintained access to their source code and any build tools in one of the following ways:
+We require developers to provide public, maintained access to their original source code and any build tool configuration files and custom build tools in one of the following ways:
 
 <ul>
-    <li>Include the source code in the deployed plugin</li>
-    <li>A link in the readme to the development location</li>
+<li>Include the source code any build tool configuration files and custom build tools in the deployed plugin</li>
+<li>A link in the readme to the development location<li></li>
 </ul>
 
-We strongly recommend you document how any development tools are to be used.
+We strongly recommend you document how any build tools are to be used.
+
+Original source code must be human readable and not be deliberately obscured.
+

--- a/guideline-04.md
+++ b/guideline-04.md
@@ -9,5 +9,8 @@ We require developers to provide public, maintained access to their original sou
 
 We strongly recommend you document how any build tools are to be used.
 
-Original source code must be human readable and not be deliberately obscured.
+Original source code must be the original edit of the code and not minified or otherwise altered after editing. 
+Original source code should be written so it is clearly understandable using sensible naming conventions and comments where appropriate
+and not deliberately obscured or obfuscated.
+
 

--- a/guideline-04.md
+++ b/guideline-04.md
@@ -3,8 +3,8 @@
 We require developers to provide public, maintained access to their original source code and any build tool configuration files and custom build tools in one of the following ways:
 
 <ul>
-<li>Include the source code any build tool configuration files and custom build tools in the deployed plugin</li>
-<li>A link in the readme to the development location<li></li>
+<li>Include the source code, any build tool configuration files and custom build tools (if any) in the deployed plugin</li>
+<li>A link in the readme to the development location</li>
 </ul>
 
 We strongly recommend you document how any build tools are to be used.


### PR DESCRIPTION
Section 4 was probably composed  before common use of build tools and now is contradictory,

Issues
1. The title use (mostly) which is far from definitive
2. Obscured code is definitively  banned in paragraph 1 “ is not permitted in the directory”,  no exception, yet  blocks built in REACT have ‘obscured' compiled code
3. Then there is an unrelated comment about build tools and source

For new plugin developers, this is confusing.   The proposed wording clarifies original source and build code and also acknowledges that the (open) build tool configuration is also an important part of being able to modify original code.