### PR TITLE
Guideline 12: Refine what is considered spammy tag use.

### DIFF
--- a/guideline-12.md
+++ b/guideline-12.md
@@ -1,6 +1,6 @@
 <h4>12. Public facing pages on WordPress.org (readmes) must not spam.</h4>
 
-Public facing pages, including readmes and translation files, may not be used to spam. Spammy behavior includes (but is not limited to) unnecessary affiliate links, tags to competitors plugins, use of over 12 tags total, blackhat SEO, and keyword stuffing.
+Public facing pages, including readmes and translation files, may not be used to spam. Spammy behavior includes (but is not limited to) unnecessary affiliate links, tags to competitors plugins, use of similar or duplicate tags, blackhat SEO, and keyword stuffing.
 
 Links to directly required products, such as themes or other plugins required for the plugin's use, are permitted within moderation. Similarly, related products may be used in tags but not competitors. If a plugin is a WooCommerce extension, it may use the tag 'woocommerce.' However if the plugin is an alternative to Akismet, it may not use that term as a tag. Repetitive use of a tag or specific term is considered to be keyword stuffing, and is not permitted.
 


### PR DESCRIPTION
See: #88 

This removes the specific tag count, as we limit the number of tags, and instead focuses on what I would consider to be "spammy tags", defined as `similar or duplicate tags`.